### PR TITLE
List operations

### DIFF
--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -171,10 +171,13 @@ let msetnx t alist =
   | Resp.Integer 0 -> return false
   | _ -> Deferred.return @@ Error `Unexpected
 
+let is_wrong_type msg = String.is_prefix msg ~prefix:"WRONGTYPE"
+
 let lpush t ~element ?(elements = []) key =
   let open Deferred.Result.Let_syntax in
   match%bind request t (["LPUSH"; key; element] @ elements) with
   | Resp.Integer n -> return n
+  | Resp.Error e when is_wrong_type e -> Deferred.return (Error (`Wrong_type key))
   | _ -> Deferred.return @@ Error `Unexpected
 
 let lrange t ~key ~start ~stop =
@@ -685,8 +688,6 @@ let llen t key =
   match%bind request t ["LLEN"; key] with
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
-
-let is_wrong_type msg = String.is_prefix msg ~prefix:"WRONGTYPE"
 
 let lpop t key =
   let open Deferred.Result.Let_syntax in

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -197,6 +197,15 @@ let lrem t ~key count ~element =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
+let lset t ~key index ~element =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["LSET"; key; string_of_int index; element] with
+  | Resp.String "OK" -> return ()
+  | Resp.Error "ERR no such key" -> Deferred.return @@ Error (`No_such_key key)
+  | Resp.Error "ERR index out of range" ->
+      Deferred.return @@ Error (`Index_out_of_range key)
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let append t ~key value =
   let open Deferred.Result.Let_syntax in
   match%bind request t ["APPEND"; key; value] with

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -191,6 +191,12 @@ let lrange t ~key ~start ~stop =
       |> Deferred.return
   | _ -> Deferred.return @@ Error `Unexpected
 
+let lrem t ~key count ~element =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["LREM"; key; string_of_int count; element] with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let append t ~key value =
   let open Deferred.Result.Let_syntax in
   match%bind request t ["APPEND"; key; value] with

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -216,6 +216,15 @@ let ltrim t ~start ~end' key =
   | Resp.String "OK" -> return ()
   | _ -> Deferred.return @@ Error `Unexpected
 
+let rpoplpush t ~source ~destination =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["RPOPLPUSH"; source; destination] with
+  | Resp.Bulk element -> return element
+  | Resp.Error e when is_wrong_type e ->
+      let keys = Printf.sprintf "%s -> %s" source destination in
+      Deferred.return (Error (`Wrong_type keys))
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let append t ~key value =
   let open Deferred.Result.Let_syntax in
   match%bind request t ["APPEND"; key; value] with

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -678,6 +678,12 @@ let linsert t ~key position ~element ~pivot =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
+let llen t key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["LLEN"; key] with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -664,6 +664,20 @@ let lindex t key index =
   | Resp.Null -> return None
   | _ -> Deferred.return @@ Error `Unexpected
 
+type position =
+  | Before
+  | After
+
+let string_of_position = function
+  | Before -> "BEFORE"
+  | After -> "AFTER"
+
+let linsert t ~key position ~element ~pivot =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["LINSERT"; key; string_of_position position; pivot; element] with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -710,13 +710,17 @@ let llen t key =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
-let lpop t key =
+let omnidirectional_pop command t key =
   let open Deferred.Result.Let_syntax in
-  match%bind request t ["LPOP"; key] with
+  match%bind request t [command; key] with
   | Resp.Bulk s -> return @@ Some s
   | Resp.Null -> return None
   | Resp.Error e when is_wrong_type e -> Deferred.return (Error (`Wrong_type key))
   | _ -> Deferred.return @@ Error `Unexpected
+
+let rpop = omnidirectional_pop "RPOP"
+
+let lpop = omnidirectional_pop "LPOP"
 
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -657,6 +657,13 @@ let restore t ~key ?ttl ?replace value =
   | Resp.String "OK" -> return ()
   | _ -> Deferred.return @@ Error `Unexpected
 
+let lindex t key index =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["LINDEX"; key; string_of_int index] with
+  | Resp.Bulk v -> return @@ Some v
+  | Resp.Null -> return None
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -90,12 +90,7 @@ let echo t message =
   | Resp.Bulk v -> return v
   | _ -> Deferred.return @@ Error `Unexpected
 
-type exist =
-  | Always
-  | Not_if_exists
-  | Only_if_exists
-
-let set t ~key ?expire ?(exist = Always) value =
+let set t ~key ?expire ?(exist = `Always) value =
   let open Deferred.Result.Let_syntax in
   let expiry =
     match expire with
@@ -104,9 +99,9 @@ let set t ~key ?expire ?(exist = Always) value =
   in
   let existence =
     match exist with
-    | Always -> []
-    | Not_if_exists -> ["NX"]
-    | Only_if_exists -> ["XX"]
+    | `Always -> []
+    | `Not_if_exists -> ["NX"]
+    | `Only_if_exists -> ["XX"]
   in
   let command = ["SET"; key; value] @ expiry @ existence in
   match%bind request t command with

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -206,6 +206,12 @@ let lset t ~key index ~element =
       Deferred.return @@ Error (`Index_out_of_range key)
   | _ -> Deferred.return @@ Error `Unexpected
 
+let ltrim t ~start ~end' key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["LTRIM"; key; string_of_int start; string_of_int end'] with
+  | Resp.String "OK" -> return ()
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let append t ~key value =
   let open Deferred.Result.Let_syntax in
   match%bind request t ["APPEND"; key; value] with

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -169,9 +169,9 @@ let msetnx t alist =
   | Resp.Integer 0 -> return false
   | _ -> Deferred.return @@ Error `Unexpected
 
-let lpush t ~key value =
+let lpush t ~element ?(elements = []) key =
   let open Deferred.Result.Let_syntax in
-  match%bind request t ["LPUSH"; key; value] with
+  match%bind request t (["LPUSH"; key; element] @ elements) with
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -300,6 +300,15 @@ val lrem
   element:string ->
   (int, [> common_error]) Deferred.Result.t
 
+val lset
+  :  t ->
+  key:string ->
+  int ->
+  element:string ->
+  ( unit,
+    [> common_error | `No_such_key of string | `Index_out_of_range of string] )
+  Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -51,6 +51,14 @@ val lpush
   string ->
   (int, [> common_error | wrong_type]) Deferred.Result.t
 
+val rpush
+  :  t ->
+  ?exist:[`Always | `Only_if_exists] ->
+  element:string ->
+  ?elements:string list ->
+  string ->
+  (int, [> common_error | wrong_type]) Deferred.Result.t
+
 val lpop : t -> string -> (string option, [> common_error | wrong_type]) Deferred.Result.t
 
 val rpop : t -> string -> (string option, [> common_error | wrong_type]) Deferred.Result.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -70,6 +70,12 @@ val lrange
   stop:int ->
   (string list, [> common_error]) Deferred.Result.t
 
+val rpoplpush
+  :  t ->
+  source:string ->
+  destination:string ->
+  (string, [> common_error | wrong_type]) Deferred.Result.t
+
 val append : t -> key:string -> string -> (int, [> common_error]) Deferred.Result.t
 
 val auth

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -53,7 +53,7 @@ val lpush
   element:string ->
   ?elements:string list ->
   string ->
-  (int, [> common_error]) Deferred.Result.t
+  (int, [> common_error | wrong_type]) Deferred.Result.t
 
 val lpop : t -> string -> (string option, [> common_error | wrong_type]) Deferred.Result.t
 

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -46,7 +46,12 @@ val mset : t -> (string * string) list -> (unit, [> common_error]) Deferred.Resu
 
 val msetnx : t -> (string * string) list -> (bool, [> common_error]) Deferred.Result.t
 
-val lpush : t -> key:string -> string -> (int, [> common_error]) Deferred.Result.t
+val lpush
+  :  t ->
+  element:string ->
+  ?elements:string list ->
+  string ->
+  (int, [> common_error]) Deferred.Result.t
 
 val lrange
   :  t ->

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -274,6 +274,18 @@ val restore
 
 val lindex : t -> string -> int -> (string option, [> common_error]) Deferred.Result.t
 
+type position =
+  | Before
+  | After
+
+val linsert
+  :  t ->
+  key:string ->
+  position ->
+  element:string ->
+  pivot:string ->
+  (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -309,6 +309,13 @@ val lset
     [> common_error | `No_such_key of string | `Index_out_of_range of string] )
   Deferred.Result.t
 
+val ltrim
+  :  t ->
+  start:int ->
+  end':int ->
+  string ->
+  (unit, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -12,16 +12,11 @@ type wrong_type = [`Wrong_type of string] [@@deriving show, eq]
 
 val echo : t -> string -> (string, [> common_error]) Deferred.Result.t
 
-type exist =
-  | Always
-  | Not_if_exists
-  | Only_if_exists
-
 val set
   :  t ->
   key:string ->
   ?expire:Time.Span.t ->
-  ?exist:exist ->
+  ?exist:[`Always | `Not_if_exists | `Only_if_exists] ->
   string ->
   (bool, [> common_error]) Deferred.Result.t
 

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -8,6 +8,8 @@ type common_error =
   | `Unexpected ]
 [@@deriving show, eq]
 
+type wrong_type = [`Wrong_type of string] [@@deriving show, eq]
+
 val echo : t -> string -> (string, [> common_error]) Deferred.Result.t
 
 type exist =
@@ -52,6 +54,8 @@ val lpush
   ?elements:string list ->
   string ->
   (int, [> common_error]) Deferred.Result.t
+
+val lpop : t -> string -> (string option, [> common_error | wrong_type]) Deferred.Result.t
 
 val lrange
   :  t ->

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -293,6 +293,13 @@ val linsert
 
 val llen : t -> string -> (int, [> common_error]) Deferred.Result.t
 
+val lrem
+  :  t ->
+  key:string ->
+  int ->
+  element:string ->
+  (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -50,6 +50,7 @@ val msetnx : t -> (string * string) list -> (bool, [> common_error]) Deferred.Re
 
 val lpush
   :  t ->
+  ?exist:[`Always | `Only_if_exists] ->
   element:string ->
   ?elements:string list ->
   string ->

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -286,6 +286,8 @@ val linsert
   pivot:string ->
   (int, [> common_error]) Deferred.Result.t
 
+val llen : t -> string -> (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -272,6 +272,8 @@ val restore
   string ->
   (unit, [> common_error]) Deferred.Result.t
 
+val lindex : t -> string -> int -> (string option, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -53,6 +53,8 @@ val lpush
 
 val lpop : t -> string -> (string option, [> common_error | wrong_type]) Deferred.Result.t
 
+val rpop : t -> string -> (string option, [> common_error | wrong_type]) Deferred.Result.t
+
 val lrange
   :  t ->
   key:string ->

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -208,34 +208,34 @@ let test_large_set_get () =
 let test_lpush () =
   Orewa.with_connection ~host @@ fun conn ->
   let key = random_key () in
-  let value = "value" in
-  let%bind res = Orewa.lpush conn ~key value in
+  let element = "value" in
+  let%bind res = Orewa.lpush conn ~element key in
   Alcotest.(check ie) "LPUSH did not work" (Ok 1) res;
   return ()
 
 let test_lpush_lrange () =
   Orewa.with_connection ~host @@ fun conn ->
   let key = random_key () in
-  let value = random_key () in
-  let value' = random_key () in
-  let%bind _ = Orewa.lpush conn ~key value in
-  let%bind _ = Orewa.lpush conn ~key value' in
+  let element = random_key () in
+  let element' = random_key () in
+  let%bind _ = Orewa.lpush conn ~element key in
+  let%bind _ = Orewa.lpush conn ~element:element' key in
   let%bind res = Orewa.lrange conn ~key ~start:0 ~stop:(-1) in
   Alcotest.(check (result (list truncated_string) err))
     "LRANGE failed"
-    (Ok [value'; value])
+    (Ok [element'; element])
     res;
   return ()
 
 let test_large_lrange () =
   Orewa.with_connection ~host @@ fun conn ->
   let key = random_key () in
-  let value = String.init exceeding_read_buffer ~f:(fun _ -> 'a') in
+  let element = String.init exceeding_read_buffer ~f:(fun _ -> 'a') in
   let values = 5 in
   let%bind expected =
     Deferred.List.init values ~f:(fun _ ->
-        let%bind _ = Orewa.lpush conn ~key value in
-        return value)
+        let%bind _ = Orewa.lpush conn ~element key in
+        return element)
   in
   let%bind res = Orewa.lrange conn ~key ~start:0 ~stop:(-1) in
   Alcotest.(check (result (list truncated_string) err)) "LRANGE failed" (Ok expected) res;
@@ -822,7 +822,7 @@ let test_sort () =
   in
   let%bind () =
     Deferred.List.iter randomly_ordered ~f:(fun value ->
-        let%bind _ = Orewa.lpush conn ~key (string_of_int value) in
+        let%bind _ = Orewa.lpush conn ~element:(string_of_int value) key in
         return ())
   in
   let%bind res = Orewa.sort conn key in
@@ -898,7 +898,7 @@ let test_type' () =
   let list_key = random_key () in
   let missing_key = random_key () in
   let%bind _ = Orewa.set conn ~key:string_key "aaaa" in
-  let%bind _ = Orewa.lpush conn ~key:list_key "aaaa" in
+  let%bind _ = Orewa.lpush conn ~element:"aaaa" list_key in
   let%bind res = Orewa.type' conn string_key in
   Alcotest.(check soe) "Finds string" (Ok (Some "string")) res;
   let%bind res = Orewa.type' conn list_key in
@@ -924,21 +924,21 @@ let test_restore () =
   let key = random_key () in
   let list_key = random_key () in
   let new_key = random_key () in
-  let value = random_key () in
-  let%bind _ = Orewa.set conn ~key value in
+  let element = random_key () in
+  let%bind _ = Orewa.set conn ~key element in
   let%bind res = Orewa.dump conn key in
   let dumped = Option.value_exn (Option.value_exn (Result.ok res)) in
   let%bind res = Orewa.restore conn ~key:new_key dumped in
   Alcotest.(check ue) "Restoring key" (Ok ()) res;
   let%bind res = Orewa.get conn new_key in
-  Alcotest.(check soe) "Correct value restored" (Ok (Some value)) res;
-  let%bind _ = Orewa.lpush conn ~key:list_key value in
+  Alcotest.(check soe) "Correct value restored" (Ok (Some element)) res;
+  let%bind _ = Orewa.lpush conn ~element list_key in
   let%bind res = Orewa.dump conn list_key in
   let dumped = Option.value_exn (Option.value_exn (Result.ok res)) in
   let%bind res = Orewa.restore conn ~key:new_key ~replace:true dumped in
   Alcotest.(check ue) "Restoring key" (Ok ()) res;
   let%bind res = Orewa.lrange conn ~key:new_key ~start:0 ~stop:(-1) in
-  Alcotest.(check (result (list string) err)) "Correct value restored" (Ok [value]) res;
+  Alcotest.(check (result (list string) err)) "Correct value restored" (Ok [element]) res;
   return ()
 
 let test_pipelining () =

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -74,12 +74,12 @@ let test_set () =
   let key = random_key () in
   let%bind res = Orewa.set conn ~key "value" in
   Alcotest.(check be) "Successfully SET" (Ok true) res;
-  let%bind res = Orewa.set conn ~key ~exist:Orewa.Not_if_exists "other" in
+  let%bind res = Orewa.set conn ~key ~exist:`Not_if_exists "other" in
   Alcotest.(check be) "Didn't SET again" (Ok false) res;
-  let%bind res = Orewa.set conn ~key ~exist:Orewa.Only_if_exists "other" in
+  let%bind res = Orewa.set conn ~key ~exist:`Only_if_exists "other" in
   Alcotest.(check be) "Successfully re-SET" (Ok true) res;
   let not_existing = random_key () in
-  let%bind res = Orewa.set conn ~key:not_existing ~exist:Orewa.Only_if_exists "value" in
+  let%bind res = Orewa.set conn ~key:not_existing ~exist:`Only_if_exists "value" in
   Alcotest.(check be) "Didn't SET non-existing" (Ok false) res;
   return ()
 

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -211,8 +211,12 @@ let test_lpush () =
   let key = random_key () in
   let not_list = random_key () in
   let element = "value" in
+  let%bind res = Orewa.lpush conn ~exist:`Only_if_exists ~element key in
+  Alcotest.(check ie) "LPUSHX to non-existing list" (Ok 0) res;
   let%bind res = Orewa.lpush conn ~element key in
   Alcotest.(check ie) "LPUSH to empty list" (Ok 1) res;
+  let%bind res = Orewa.lpush conn ~exist:`Always ~element key in
+  Alcotest.(check ie) "LPUSH to existing list" (Ok 2) res;
   let%bind _ = Orewa.set conn ~key:not_list element in
   let%bind res = Orewa.lpush conn ~element not_list in
   Alcotest.(check ie) "LPUSH to not a list" (Error (`Wrong_type not_list)) res;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1080,6 +1080,20 @@ let test_lset () =
     res;
   return ()
 
+let test_ltrim () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let element = random_key () in
+  let elements = 10 in
+  let%bind _ =
+    List.init elements ~f:(fun _ -> Orewa.lpush conn key ~element) |> Deferred.all
+  in
+  let%bind res = Orewa.ltrim conn ~start:0 ~end':4 key in
+  Alcotest.(check ue) "Trimming list" (Ok ()) res;
+  let%bind res = Orewa.llen conn key in
+  Alcotest.(check ie) "List is trimmed" (Ok 5) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1096,6 +1110,7 @@ let tests =
       test_case "LRANGE" `Slow test_lpush_lrange;
       test_case "LREM" `Slow test_lrem;
       test_case "LSET" `Slow test_lset;
+      test_case "LTRIM" `Slow test_ltrim;
       test_case "Large LRANGE" `Slow test_large_lrange;
       test_case "APPEND" `Slow test_append;
       test_case "AUTH" `Slow test_auth;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -977,6 +977,17 @@ let test_close () =
   Alcotest.(check soe) "Get test key" (Error `Connection_closed) res;
   return ()
 
+let test_lindex () =
+  let%bind conn = Orewa.connect ?port:None ~host in
+  let key = random_key () in
+  let%bind res = Orewa.lindex conn key 0 in
+  Alcotest.(check soe) "Get index of not existing list" (Ok None) res;
+  let not_list = random_key () in
+  let%bind _ = Orewa.set conn ~key:not_list "this is not a list" in
+  let%bind res = Orewa.lindex conn key 0 in
+  Alcotest.(check soe) "Get index of not a list" (Ok None) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1040,7 +1051,8 @@ let tests =
       test_case "DUMP" `Slow test_dump;
       test_case "RESTORE" `Slow test_restore;
       test_case "PIPELINE" `Slow test_pipelining;
-      test_case "CLOSE" `Slow test_close ]
+      test_case "CLOSE" `Slow test_close;
+      test_case "LINDEX" `Slow test_lindex ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -978,7 +978,7 @@ let test_close () =
   return ()
 
 let test_lindex () =
-  let%bind conn = Orewa.connect ?port:None ~host in
+  Orewa.with_connection ~host @@ fun conn ->
   let key = random_key () in
   let%bind res = Orewa.lindex conn key 0 in
   Alcotest.(check soe) "Get index of not existing list" (Ok None) res;
@@ -986,6 +986,13 @@ let test_lindex () =
   let%bind _ = Orewa.set conn ~key:not_list "this is not a list" in
   let%bind res = Orewa.lindex conn key 0 in
   Alcotest.(check soe) "Get index of not a list" (Ok None) res;
+  return ()
+
+let test_linsert () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let%bind res = Orewa.linsert conn ~key Orewa.Before ~element:"Hello" ~pivot:"World" in
+  Alcotest.(check ie) "Insert into nonexisting list" (Ok 0) res;
   return ()
 
 let tests =
@@ -1052,6 +1059,7 @@ let tests =
       test_case "RESTORE" `Slow test_restore;
       test_case "PIPELINE" `Slow test_pipelining;
       test_case "CLOSE" `Slow test_close;
+      test_case "LINSERT" `Slow test_linsert;
       test_case "LINDEX" `Slow test_lindex ]
 
 let () =

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -995,6 +995,13 @@ let test_linsert () =
   Alcotest.(check ie) "Insert into nonexisting list" (Ok 0) res;
   return ()
 
+let test_llen () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let%bind res = Orewa.llen conn key in
+  Alcotest.(check ie) "Lenght of nonexisting list" (Ok 0) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1060,6 +1067,7 @@ let tests =
       test_case "PIPELINE" `Slow test_pipelining;
       test_case "CLOSE" `Slow test_close;
       test_case "LINSERT" `Slow test_linsert;
+      test_case "LLEN" `Slow test_llen;
       test_case "LINDEX" `Slow test_lindex ]
 
 let () =

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -209,9 +209,13 @@ let test_large_set_get () =
 let test_lpush () =
   Orewa.with_connection ~host @@ fun conn ->
   let key = random_key () in
+  let not_list = random_key () in
   let element = "value" in
   let%bind res = Orewa.lpush conn ~element key in
-  Alcotest.(check ie) "LPUSH did not work" (Ok 1) res;
+  Alcotest.(check ie) "LPUSH to empty list" (Ok 1) res;
+  let%bind _ = Orewa.set conn ~key:not_list element in
+  let%bind res = Orewa.lpush conn ~element not_list in
+  Alcotest.(check ie) "LPUSH to not a list" (Error (`Wrong_type not_list)) res;
   return ()
 
 let test_lpush_lrange () =


### PR DESCRIPTION
Most operations are implemented, but currently missing ones ("right" and "blocking"):

- [ ] `BLPOP`
- [ ] `BRPOP`
- [ ] `BRPOPLPUSH`
- [x] `RPOP`
- [x] `RPOPLPUSH`
- [x] `RPUSH`
- [x] `RPUSHX`