### PR TITLE
Cache opam in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services:
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
+cache:
+    directories:
+    - $HOME/.opam
 env:
   global:
     - PACKAGE=orewa


### PR DESCRIPTION
The cumulative set of CI builds can take over 2 hours because we are downloading and building all ocaml dependencies each time.

Cache $HOME/.opam. This reduces each build to about 4-5 minutes.