### PR TITLE
Hashmaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - PACKAGE=orewa
     - TESTS=true
-    - POST_INSTALL_HOOK="opam install alcotest alcotest-async && make integration"
+    - POST_INSTALL_HOOK="opam reinstall --with-test orewa && make integration"
   matrix:
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.05

--- a/dune-project
+++ b/dune-project
@@ -16,8 +16,9 @@
     (core (>= v0.11))
     (dune (>= 1.10))
     (ppx_let (>= v0.11))
-    (alcotest (and :with_test (>= 0.8.4)))
-    (alcotest-async (and :with_test (>= 0.8.2)))
+    (alcotest (and :with-test (>= 0.8.4)))
+    (alcotest-async (and :with-test (>= 0.8.2)))
+    (fmt (and :with-test (>= 0.8.6)))
     (ppx_deriving (>= 4.2)))
   (synopsis "Async-friendly Redis client")
   (description "Async-friendly Redis client

--- a/orewa.opam
+++ b/orewa.opam
@@ -28,7 +28,8 @@ depends: [
   "core" {>= "v0.11"}
   "dune" {>= "1.10"}
   "ppx_let" {>= "v0.11"}
-  "alcotest" {with_test & >= "0.8.4"}
-  "alcotest-async" {with_test & >= "0.8.2"}
+  "alcotest" {with-test & >= "0.8.4"}
+  "alcotest-async" {with-test & >= "0.8.2"}
+  "fmt" {with-test & >= "0.8.6"}
   "ppx_deriving" {>= "4.2"}
 ]

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -807,6 +807,12 @@ let hexists t ~field key =
   | Resp.Integer 0 -> return false
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hincrby t ~field key increment =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["HINCRBY"; key; field; string_of_int increment] with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -831,6 +831,12 @@ let hkeys t key =
       Deferred.return @@ Result.all keys
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hlen t key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["HLEN"; key] with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -744,6 +744,12 @@ let hset t ~element ?(elements = []) key =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hget t ~field key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["HGET"; key; field] with
+  | Resp.Bulk v -> return v
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -819,9 +819,9 @@ let hincrbyfloat t ~field key increment =
   | Resp.Bulk fl -> return @@ float_of_string fl
   | _ -> Deferred.return @@ Error `Unexpected
 
-let hkeys t key =
+let generic_keyvals command t key =
   let open Deferred.Result.Let_syntax in
-  match%bind request t ["HKEYS"; key] with
+  match%bind request t [command; key] with
   | Resp.Array xs ->
       let keys =
         List.map xs ~f:(function
@@ -830,6 +830,10 @@ let hkeys t key =
       in
       Deferred.return @@ Result.all keys
   | _ -> Deferred.return @@ Error `Unexpected
+
+let hkeys = generic_keyvals "HKEYS"
+
+let hvals = generic_keyvals "HVALS"
 
 let hlen t key =
   let open Deferred.Result.Let_syntax in

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -794,6 +794,12 @@ let hgetall t key =
       | `Duplicate_key _ -> Deferred.return @@ Error `Unexpected)
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hdel t ?(fields = []) ~field key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t (["HDEL"; key; field] @ fields) with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -837,6 +837,12 @@ let hlen t key =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hstrlen t ~field key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["HSTRLEN"; key; field] with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -735,6 +735,15 @@ let rpop = omnidirectional_pop "RPOP"
 
 let lpop = omnidirectional_pop "LPOP"
 
+let hset t ~element ?(elements = []) key =
+  let open Deferred.Result.Let_syntax in
+  let field_values =
+    element :: elements |> List.map ~f:(fun (f, v) -> [f; v]) |> List.concat
+  in
+  match%bind request t (["HSET"; key] @ field_values) with
+  | Resp.Integer n -> return n
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -813,6 +813,12 @@ let hincrby t ~field key increment =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hincrbyfloat t ~field key increment =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["HINCRBYFLOAT"; key; field; string_of_float increment] with
+  | Resp.Bulk fl -> return @@ float_of_string fl
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.ml
+++ b/src/orewa.ml
@@ -800,6 +800,13 @@ let hdel t ?(fields = []) ~field key =
   | Resp.Integer n -> return n
   | _ -> Deferred.return @@ Error `Unexpected
 
+let hexists t ~field key =
+  let open Deferred.Result.Let_syntax in
+  match%bind request t ["HEXISTS"; key; field] with
+  | Resp.Integer 1 -> return true
+  | Resp.Integer 0 -> return false
+  | _ -> Deferred.return @@ Error `Unexpected
+
 let with_connection ?(port = 6379) ~host f =
   let where = Tcp.Where_to_connect.of_host_and_port @@ Host_and_port.create ~host ~port in
   Tcp.with_connection where @@ fun _socket reader writer ->

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -347,6 +347,8 @@ val hmget
   string ->
   (string String.Map.t, [> common_error]) Deferred.Result.t
 
+val hgetall : t -> string -> (string String.Map.t, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -374,6 +374,8 @@ val hincrbyfloat
 
 val hkeys : t -> string -> (string list, [> common_error]) Deferred.Result.t
 
+val hvals : t -> string -> (string list, [> common_error]) Deferred.Result.t
+
 val hlen : t -> string -> (int, [> common_error]) Deferred.Result.t
 
 val hstrlen : t -> field:string -> string -> (int, [> common_error]) Deferred.Result.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -349,6 +349,13 @@ val hmget
 
 val hgetall : t -> string -> (string String.Map.t, [> common_error]) Deferred.Result.t
 
+val hdel
+  :  t ->
+  ?fields:string list ->
+  field:string ->
+  string ->
+  (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -374,6 +374,8 @@ val hincrbyfloat
 
 val hkeys : t -> string -> (string list, [> common_error]) Deferred.Result.t
 
+val hlen : t -> string -> (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -356,6 +356,8 @@ val hdel
   string ->
   (int, [> common_error]) Deferred.Result.t
 
+val hexists : t -> field:string -> string -> (bool, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -365,6 +365,13 @@ val hincrby
   int ->
   (int, [> common_error]) Deferred.Result.t
 
+val hincrbyfloat
+  :  t ->
+  field:string ->
+  string ->
+  float ->
+  (float, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -358,6 +358,13 @@ val hdel
 
 val hexists : t -> field:string -> string -> (bool, [> common_error]) Deferred.Result.t
 
+val hincrby
+  :  t ->
+  field:string ->
+  string ->
+  int ->
+  (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -341,6 +341,12 @@ val hset
 
 val hget : t -> field:string -> string -> (string, [> common_error]) Deferred.Result.t
 
+val hmget
+  :  t ->
+  fields:string list ->
+  string ->
+  (string String.Map.t, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -376,6 +376,8 @@ val hkeys : t -> string -> (string list, [> common_error]) Deferred.Result.t
 
 val hlen : t -> string -> (int, [> common_error]) Deferred.Result.t
 
+val hstrlen : t -> field:string -> string -> (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -339,6 +339,8 @@ val hset
   string ->
   (int, [> common_error]) Deferred.Result.t
 
+val hget : t -> field:string -> string -> (string, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -332,6 +332,13 @@ val ltrim
   string ->
   (unit, [> common_error]) Deferred.Result.t
 
+val hset
+  :  t ->
+  element:string * string ->
+  ?elements:(string * string) list ->
+  string ->
+  (int, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -380,6 +380,13 @@ val hlen : t -> string -> (int, [> common_error]) Deferred.Result.t
 
 val hstrlen : t -> field:string -> string -> (int, [> common_error]) Deferred.Result.t
 
+val hscan
+  :  t ->
+  ?pattern:string ->
+  ?count:int ->
+  string ->
+  (string * string) Pipe.Reader.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/src/orewa.mli
+++ b/src/orewa.mli
@@ -372,6 +372,8 @@ val hincrbyfloat
   float ->
   (float, [> common_error]) Deferred.Result.t
 
+val hkeys : t -> string -> (string list, [> common_error]) Deferred.Result.t
+
 val connect : ?port:int -> host:string -> t Deferred.t
 
 val close : t -> unit Deferred.t

--- a/test/integration/dune
+++ b/test/integration/dune
@@ -1,7 +1,7 @@
 (executable
  (name test)
  (preprocess
-  (pps ppx_let ppx_deriving.show ppx_deriving.eq))
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_deriving.ord))
  (libraries alcotest alcotest-async core async orewa))
 
 (alias

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1302,6 +1302,19 @@ let test_hkeys () =
   Alcotest.(check sle) "Enumerating existing key" (Ok [field]) res;
   return ()
 
+let test_hlen () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind res = Orewa.hlen conn key in
+  Alcotest.(check ie) "Empty hash map" (Ok 0) res;
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hlen conn key in
+  Alcotest.(check ie) "Map with fields" (Ok 1) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1384,7 +1397,8 @@ let tests =
       test_case "HEXISTS" `Slow test_hexists;
       test_case "HINCRBY" `Slow test_hincrby;
       test_case "HINCRBYFLOAT" `Slow test_hincrbyfloat;
-      test_case "HKEYS" `Slow test_hkeys ]
+      test_case "HKEYS" `Slow test_hkeys;
+      test_case "HLEN" `Slow test_hlen ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1247,6 +1247,22 @@ let test_hdel () =
   Alcotest.(check ie) "Single delete from filled hashtable" (Ok 2) res;
   return ()
 
+let test_hexists () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind res = Orewa.hexists conn ~field key in
+  Alcotest.(check be) "Asking for nonexisting field on missing key" (Ok false) res;
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hexists conn ~field key in
+  Alcotest.(check be) "Asking for existing key" (Ok true) res;
+  let%bind _ = Orewa.hdel conn ~field key in
+  let%bind res = Orewa.hexists conn ~field key in
+  Alcotest.(check be) "Asking for deleted key" (Ok false) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1325,7 +1341,8 @@ let tests =
       test_case "HGET" `Slow test_hget;
       test_case "HMGET" `Slow test_hmget;
       test_case "HGETALL" `Slow test_hgetall;
-      test_case "HDEL" `Slow test_hdel ]
+      test_case "HDEL" `Slow test_hdel;
+      test_case "HEXISTS" `Slow test_hexists ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1178,6 +1178,17 @@ let test_hset () =
   Alcotest.(check ie) "Set multiple elements" (Ok 3) res;
   return ()
 
+let test_hget () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hget conn ~field key in
+  Alcotest.(check se) "Getting the value that was set" (Ok value) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1252,7 +1263,8 @@ let tests =
       test_case "LINSERT" `Slow test_linsert;
       test_case "LLEN" `Slow test_llen;
       test_case "LINDEX" `Slow test_lindex;
-      test_case "HSET" `Slow test_hset ]
+      test_case "HSET" `Slow test_hset;
+      test_case "HGET" `Slow test_hget ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1155,6 +1155,29 @@ let test_ltrim () =
   Alcotest.(check ie) "List is trimmed" (Ok 5) res;
   return ()
 
+let test_hset () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let random_element () =
+    let field = random_key () in
+    let value = random_key () in
+    field, value
+  in
+  let element = random_element () in
+  let%bind res = Orewa.hset conn ~element key in
+  Alcotest.(check ie) "Set single element" (Ok 1) res;
+  let%bind res = Orewa.hset conn ~element key in
+  Alcotest.(check ie) "Resetting is no-op" (Ok 0) res;
+  let%bind res =
+    Orewa.hset
+      conn
+      ~element:(random_element ())
+      ~elements:[random_element (); random_element ()]
+      key
+  in
+  Alcotest.(check ie) "Set multiple elements" (Ok 3) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1228,7 +1251,8 @@ let tests =
       test_case "CLOSE" `Slow test_close;
       test_case "LINSERT" `Slow test_linsert;
       test_case "LLEN" `Slow test_llen;
-      test_case "LINDEX" `Slow test_lindex ]
+      test_case "LINDEX" `Slow test_lindex;
+      test_case "HSET" `Slow test_hset ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -26,6 +26,8 @@ let be = Alcotest.(result bool err)
 
 let ie = Alcotest.(result int err)
 
+let fe = Alcotest.(result (float 0.01) err)
+
 let se = Alcotest.(result string err)
 
 let soe = Alcotest.(result (option string) err)
@@ -1274,6 +1276,17 @@ let test_hincrby () =
   Alcotest.(check ie) "Incrementing existing key" (Ok (2 * value)) res;
   return ()
 
+let test_hincrbyfloat () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = 42. in
+  let%bind res = Orewa.hincrbyfloat conn ~field key value in
+  Alcotest.(check fe) "Incrementing missing key" (Ok value) res;
+  let%bind res = Orewa.hincrbyfloat conn ~field key value in
+  Alcotest.(check fe) "Incrementing existing key" (Ok Float.(2. * value)) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1354,7 +1367,8 @@ let tests =
       test_case "HGETALL" `Slow test_hgetall;
       test_case "HDEL" `Slow test_hdel;
       test_case "HEXISTS" `Slow test_hexists;
-      test_case "HINCRBY" `Slow test_hincrby ]
+      test_case "HINCRBY" `Slow test_hincrby;
+      test_case "HINCRBYFLOAT" `Slow test_hincrbyfloat ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1263,6 +1263,17 @@ let test_hexists () =
   Alcotest.(check be) "Asking for deleted key" (Ok false) res;
   return ()
 
+let test_hincrby () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = 42 in
+  let%bind res = Orewa.hincrby conn ~field key value in
+  Alcotest.(check ie) "Incrementing missing key" (Ok value) res;
+  let%bind res = Orewa.hincrby conn ~field key value in
+  Alcotest.(check ie) "Incrementing existing key" (Ok (2 * value)) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1342,7 +1353,8 @@ let tests =
       test_case "HMGET" `Slow test_hmget;
       test_case "HGETALL" `Slow test_hgetall;
       test_case "HDEL" `Slow test_hdel;
-      test_case "HEXISTS" `Slow test_hexists ]
+      test_case "HEXISTS" `Slow test_hexists;
+      test_case "HINCRBY" `Slow test_hincrby ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1228,6 +1228,25 @@ let test_hgetall () =
   Alcotest.(check sme) "Getting a map of elements" (Ok expected) res;
   return ()
 
+let test_hdel () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind res = Orewa.hdel conn ~field key in
+  Alcotest.(check ie) "Deleting from empty hashtable" (Ok 0) res;
+  let field' = random_key () in
+  let element' = field', value in
+  let field'' = random_key () in
+  let element'' = field'', value in
+  let%bind _ = Orewa.hset conn ~element ~elements:[element'; element''] key in
+  let%bind res = Orewa.hdel conn ~field key in
+  Alcotest.(check ie) "Single delete from filled hashtable" (Ok 1) res;
+  let%bind res = Orewa.hdel conn ~field:field' ~fields:[field''] key in
+  Alcotest.(check ie) "Single delete from filled hashtable" (Ok 2) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1305,7 +1324,8 @@ let tests =
       test_case "HSET" `Slow test_hset;
       test_case "HGET" `Slow test_hget;
       test_case "HMGET" `Slow test_hmget;
-      test_case "HGETALL" `Slow test_hgetall ]
+      test_case "HGETALL" `Slow test_hgetall;
+      test_case "HDEL" `Slow test_hdel ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -30,6 +30,8 @@ let fe = Alcotest.(result (float 0.01) err)
 
 let se = Alcotest.(result string err)
 
+let sle = Alcotest.(result (list string) err)
+
 let soe = Alcotest.(result (option string) err)
 
 let some_string = Alcotest.testable String.pp (const (const true))
@@ -1287,6 +1289,19 @@ let test_hincrbyfloat () =
   Alcotest.(check fe) "Incrementing existing key" (Ok Float.(2. * value)) res;
   return ()
 
+let test_hkeys () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind res = Orewa.hkeys conn key in
+  Alcotest.(check sle) "Empty hash map" (Ok []) res;
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hkeys conn key in
+  Alcotest.(check sle) "Enumerating existing key" (Ok [field]) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1368,7 +1383,8 @@ let tests =
       test_case "HDEL" `Slow test_hdel;
       test_case "HEXISTS" `Slow test_hexists;
       test_case "HINCRBY" `Slow test_hincrby;
-      test_case "HINCRBYFLOAT" `Slow test_hincrbyfloat ]
+      test_case "HINCRBYFLOAT" `Slow test_hincrbyfloat;
+      test_case "HKEYS" `Slow test_hkeys ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1216,6 +1216,21 @@ let test_hmget () =
   Alcotest.(check sme) "Getting the value that was set" (Ok expected) res;
   return ()
 
+let test_hgetall () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let%bind res = Orewa.hgetall conn key in
+  let expected = String.Map.of_alist_exn [] in
+  Alcotest.(check sme) "Getting an empty map on empty key" (Ok expected) res;
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hgetall conn key in
+  let expected = String.Map.of_alist_exn [element] in
+  Alcotest.(check sme) "Getting a map of elements" (Ok expected) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1292,7 +1307,8 @@ let tests =
       test_case "LINDEX" `Slow test_lindex;
       test_case "HSET" `Slow test_hset;
       test_case "HGET" `Slow test_hget;
-      test_case "HMGET" `Slow test_hmget ]
+      test_case "HMGET" `Slow test_hmget;
+      test_case "HGETALL" `Slow test_hgetall ]
 
 let () =
   Log.Global.set_level `Debug;

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1302,6 +1302,19 @@ let test_hkeys () =
   Alcotest.(check sle) "Enumerating existing key" (Ok [field]) res;
   return ()
 
+let test_hvals () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind res = Orewa.hvals conn key in
+  Alcotest.(check sle) "Empty hash map" (Ok []) res;
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hvals conn key in
+  Alcotest.(check sle) "Enumerating existing key" (Ok [value]) res;
+  return ()
+
 let test_hlen () =
   Orewa.with_connection ~host @@ fun conn ->
   let key = random_key () in
@@ -1411,6 +1424,7 @@ let tests =
       test_case "HINCRBY" `Slow test_hincrby;
       test_case "HINCRBYFLOAT" `Slow test_hincrbyfloat;
       test_case "HKEYS" `Slow test_hkeys;
+      test_case "HVALS" `Slow test_hvals;
       test_case "HLEN" `Slow test_hlen;
       test_case "HSTRLEN" `Slow test_hstrlen ]
 

--- a/test/integration/test.ml
+++ b/test/integration/test.ml
@@ -1315,6 +1315,19 @@ let test_hlen () =
   Alcotest.(check ie) "Map with fields" (Ok 1) res;
   return ()
 
+let test_hstrlen () =
+  Orewa.with_connection ~host @@ fun conn ->
+  let key = random_key () in
+  let field = random_key () in
+  let value = random_key () in
+  let element = field, value in
+  let%bind res = Orewa.hstrlen conn ~field key in
+  Alcotest.(check ie) "Empty hash map" (Ok 0) res;
+  let%bind _ = Orewa.hset conn ~element key in
+  let%bind res = Orewa.hstrlen conn ~field key in
+  Alcotest.(check ie) "Map with a field" (Ok (String.length value)) res;
+  return ()
+
 let tests =
   Alcotest_async.
     [ test_case "ECHO" `Slow test_echo;
@@ -1398,7 +1411,8 @@ let tests =
       test_case "HINCRBY" `Slow test_hincrby;
       test_case "HINCRBYFLOAT" `Slow test_hincrbyfloat;
       test_case "HKEYS" `Slow test_hkeys;
-      test_case "HLEN" `Slow test_hlen ]
+      test_case "HLEN" `Slow test_hlen;
+      test_case "HSTRLEN" `Slow test_hstrlen ]
 
 let () =
   Log.Global.set_level `Debug;


### PR DESCRIPTION
The most major hashtable operations exist now, some important ones missing are currently:

- [x] `HINCRBY`
- [x] `HKEYS`
- [x] `HLEN`
- [x] `HSCAN`
- [x] `HSTRLEN`
- [x] `HVALS`

This also fixes compilation with newer JST versions, which redefine `(=)`.